### PR TITLE
Coquille dans nom de fichier

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
 						<li><img src="../../../medias/spooky_tower/spooky_antoine.jpg" alt="Antoine"> Antoine Allard</li>
 						<li><img src="../../../medias/spooky_tower/spooky_quentin.jpg" alt="Quentin"> Quentin Lequenne</li>
 						<li><img src="../../../medias/spooky_tower/spooky_felix.jpg" alt="Félix"> Félix Jasmin</li>
-						<li><img src="../../../medias/spooky_tower/spooky_williamt.jpg" alt="William"> William Racine</li>
+						<li><img src="../../../medias/spooky_tower/spooky_william.jpg" alt="William"> William Racine</li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
Corrigé une coquille dans un nom de fichier image.